### PR TITLE
Stop execution of actions if clip is removed

### DIFF
--- a/lib/interpreter.ts
+++ b/lib/interpreter.ts
@@ -293,6 +293,14 @@ function isAVM1MovieClip(obj): boolean {
 		obj instanceof AVM1MovieClip;
 }
 
+// Removing a movieclip should stop the execution of its actions immediately
+function stopIfClipRemoved(ectx: ExecutionContext, clip: AVM1Object | AVM1Function) {
+	if (isAVM1MovieClip(clip) && clip.isGhost) {
+		console.log("Stopping actions for ghost clip");
+		ectx.isEndOfActions = true;
+	}
+}
+
 function as2GetType(v): string {
 	if (v === null) {
 		return 'null';
@@ -2233,6 +2241,7 @@ function avm1_callableHelper(ectx: ExecutionContext, obj: AVM1Object | AVM1Funct
 	}
 	frame.resetCallee();
 
+	stopIfClipRemoved(ectx, obj);
 	return { result, called };
 }
 


### PR DESCRIPTION
This is a first attempt at fixing #11. It fixes the infinite loop in Age of War, but not the minimal reproduction attached to the issue.